### PR TITLE
Added `g:latex_toc_split_vertically`

### DIFF
--- a/autoload/latex.vim
+++ b/autoload/latex.vim
@@ -266,6 +266,7 @@ function! s:init_options() " {{{1
   call latex#util#set_default('g:latex_toc_resize', 1)
   call latex#util#set_default('g:latex_toc_secnumdepth', 3)
   call latex#util#set_default('g:latex_toc_split_side', 'leftabove')
+  call latex#util#set_default('g:latex_toc_split_vertically', 1)
   call latex#util#set_default('g:latex_toc_width', 30)
   call latex#util#set_default('g:latex_view_enabled', 1)
 endfunction

--- a/autoload/latex/toc.vim
+++ b/autoload/latex/toc.vim
@@ -36,7 +36,11 @@ function! latex#toc#open() " {{{1
   if g:latex_toc_resize
     silent exe "set columns+=" . g:latex_toc_width
   endif
-  silent exe g:latex_toc_split_side g:latex_toc_width . 'vnew LaTeX\ TOC'
+  if g:latex_toc_split_vertically == 1
+    silent exe g:latex_toc_split_side g:latex_toc_width . 'vnew LaTeX\ TOC'
+  else
+    silent exe g:latex_toc_split_side g:latex_toc_width . 'new LaTeX\ TOC'
+  endif
 
   " Set buffer local variables
   let b:toc = toc

--- a/doc/latex.txt
+++ b/doc/latex.txt
@@ -304,6 +304,7 @@ Overview:~
   |g:latex_toc_resize|
   |g:latex_toc_secnumdepth|
   |g:latex_toc_split_side|
+  |g:latex_toc_split_vertically|
   |g:latex_toc_width|
   |g:latex_view_enabled|
   |g:latex_view_general_viewer|
@@ -525,6 +526,11 @@ http://en.wikibooks.org/w/index.php?title=LaTeX/Document_Structure >
                                                       *g:latex_toc_split_side*
 Define where the TOC window is opened. >
   let g:latex_toc_split_side = 'leftabove'
+<
+                                                      *g:latex_toc_split_vertically*
+If enabled, TOC window split vertically. Otherwise TOC window split
+horizontally. >
+  let g:latex_toc_split_vertically = 1
 <
                                                            *g:latex_toc_width*
 Set width of TOC window. >
@@ -922,6 +928,7 @@ Associated settings:
     |g:latex_toc_resize|
     |g:latex_toc_secnumdepth|
     |g:latex_toc_split_side|
+    |g:latex_toc_split_vertically|
     |g:latex_toc_width|
 
 Functions:


### PR DESCRIPTION
This option specify whether TOC window split vertically or horizontally.