### PR TITLE
Fixed TOC space width

### DIFF
--- a/autoload/latextoc.vim
+++ b/autoload/latextoc.vim
@@ -117,7 +117,8 @@ function! s:print_entry(entry) " {{{1
     let entry .= printf(s:num_format, level >= b:toc_secnumdepth + 2
           \ ? '' : strpart(s:print_number(a:entry.number), 0, s:width))
   endif
-  let entry .= printf('%-140s%s', a:entry.title, level)
+  let space_width = 140 - strwidth(a:entry.title)
+  let entry .= a:entry.title . repeat(' ', space_width) . level
 
   call append('$', entry)
 endfunction


### PR DESCRIPTION
Fix TOC space width in order to support multibyte character.

![before](https://cloud.githubusercontent.com/assets/186170/5589038/ece9deb6-9158-11e4-84e6-65591ec65938.png)
![after](https://cloud.githubusercontent.com/assets/186170/5589039/ed030260-9158-11e4-9546-19c6929134aa.png)
