### PR TITLE
Fix for issue #105

### DIFF
--- a/autoload/latex/latexmk.vim
+++ b/autoload/latex/latexmk.vim
@@ -110,7 +110,7 @@ function! latex#latexmk#clean(full) " {{{1
   " Run latexmk clean process
   "
   if has('win32')
-    let cmd = 'cd /D ' . shellescape(data.root) . ' & '
+	let cmd = 'cd /D "' . data.root . '" & '
   else
     let cmd = 'cd ' . shellescape(data.root) . '; '
   endif
@@ -120,7 +120,7 @@ function! latex#latexmk#clean(full) " {{{1
   else
     let cmd .= ' -c '
   endif
-  let cmd .= shellescape(data.base)
+  let cmd .= latex#util#fnameescape(data.base)
   let g:latex#data[b:latex.id].cmds.clean = cmd
   let exe = {
         \ 'cmd' : cmd,
@@ -331,7 +331,7 @@ function! s:latexmk_build_cmd(data) " {{{1
   let tmp = tempname()
 
   if has('win32')
-    let cmd  = 'cd /D ' . shellescape(a:data.root)
+    let cmd  = 'cd /D "' . a:data.root . '"'
     let cmd .= ' && set max_print_line=2000 & latexmk'
   else
     let cmd  = 'cd ' . shellescape(a:data.root)
@@ -363,7 +363,7 @@ function! s:latexmk_build_cmd(data) " {{{1
     let s:first_callback = 1
   endif
 
-  let cmd .= ' ' . shellescape(a:data.base)
+  let cmd .= ' ' . latex#util#fnameescape(a:data.base)
 
   if g:latex_latexmk_continuous || g:latex_latexmk_background
     if has('win32')

--- a/autoload/latex/util.vim
+++ b/autoload/latex/util.vim
@@ -6,18 +6,6 @@
 " Utility functions sorted by name
 "
 
-function! latex#util#fnameescape(path)
-  "
-  " In a Windows environment, a path used in "cmd" only needs to be
-  " enclosed by double quotes. shellscape() on Windows with 
-  " "shellslash" set will produce a path enclosed by single quotes, 
-  " which "cmd" does not recognize and reports an error.
-  " Any path that goes into latex#util#execute() should be 
-  " processed through this function.
-  "
-  return has('win32') ? '"' . a:path . '"' : shellescape(a:path)
-endfunction
-
 function! latex#util#convert_back(line) " {{{1
   "
   " Substitute stuff like '\IeC{\"u}' to corresponding unicode symbols
@@ -97,7 +85,7 @@ let s:convert_back_list = map([
 function! latex#util#error_deprecated(variable) " {{{1
   if exists(a:variable)
     echoerr "Deprecation error: " . a:variable
-    echoerr "Please red docs for more info!"
+	echoerr "Please read docs for more info!"
     echoerr ":h vim-latex-changelog"
   endif
 endfunction
@@ -182,7 +170,19 @@ function! latex#util#execute(exe) " {{{1
     redraw!
   endif
 endfunction
-" }}}1
+
+function! latex#util#fnameescape(path) " {{{1
+  "
+  " In a Windows environment, a path used in "cmd" only needs to be
+  " enclosed by double quotes. shellscape() on Windows with 
+  " "shellslash" set will produce a path enclosed by single quotes, 
+  " which "cmd" does not recognize and reports an error.
+  " Any path that goes into latex#util#execute() should be 
+  " processed through this function.
+  "
+  return has('win32') ? '"' . a:path . '"' : shellescape(a:path)
+endfunction
+
 function! latex#util#get_env(...) " {{{1
   " latex#util#get_env([with_pos])
   " Returns:

--- a/autoload/latex/util.vim
+++ b/autoload/latex/util.vim
@@ -6,6 +6,18 @@
 " Utility functions sorted by name
 "
 
+function! latex#util#fnameescape(path)
+  "
+  " In a Windows environment, a path used in "cmd" only needs to be
+  " enclosed by double quotes. shellscape() on Windows with 
+  " "shellslash" set will produce a path enclosed by single quotes, 
+  " which "cmd" does not recognize and reports an error.
+  " Any path that goes into latex#util#execute() should be 
+  " processed through this function.
+  "
+  return has('win32') ? '"' . a:path . '"' : shellescape(a:path)
+endfunction
+
 function! latex#util#convert_back(line) " {{{1
   "
   " Substitute stuff like '\IeC{\"u}' to corresponding unicode symbols

--- a/autoload/latex/view.vim
+++ b/autoload/latex/view.vim
@@ -77,7 +77,7 @@ function! latex#view#general() " {{{1
     return
   endif
   let exe.cmd .= ' ' . g:latex_view_general_options
-  let exe.cmd .= ' ' . shellescape(outfile)
+  let exe.cmd .= ' ' . latex#util#fnameescape(outfile)
 
   call latex#util#execute(exe)
   let g:latex#data[b:latex.id].cmds.view = exe.cmd
@@ -180,9 +180,9 @@ function! latex#view#sumatrapdf() "{{{1
 
   let exe = {}
   let exe.cmd = 'SumatraPDF ' . g:latex_view_sumatrapdf_options
-  let exe.cmd .= ' -forward-search ' . shellescape(expand('%:p'))
+  let exe.cmd .= ' -forward-search ' . latex#util#fnameescape(expand('%:p'))
   let exe.cmd .= ' ' . line('.')
-  let exe.cmd .= ' ' . shellescape(outfile)
+  let exe.cmd .= ' ' . latex#util#fnameescape(outfile)
 
   call latex#util#execute(exe)
   let g:latex#data[b:latex.id].cmds.view = exe.cmd
@@ -198,8 +198,8 @@ function! latex#view#okular() "{{{1
 
   let exe = {}
   let exe.cmd = 'okular ' . g:latex_view_okular_options
-  let exe.cmd .= ' --unique ' . shellescape(outfile)
-  let exe.cmd .= '\#src:' . line('.') . shellescape(expand('%:p'))
+  let exe.cmd .= ' --unique ' . latex#util#fnameescape(outfile)
+  let exe.cmd .= '\#src:' . line('.') . latex#util#fnameescape(expand('%:p'))
 
   call latex#util#execute(exe)
   let g:latex#data[b:latex.id].cmds.view = exe.cmd
@@ -264,8 +264,8 @@ function! s:mupdf_forward_search() "{{{1
   let l:cmd = "synctex view -i "
         \ . (line(".") + 1) . ":"
         \ . (col(".") + 1) . ":"
-        \ . shellescape(expand("%:p"))
-        \ . " -o " . shellescape(outfile)
+		\ . latex#util#fnameescape(expand("%:p"))
+        \ . " -o " . latex#util#fnameescape(outfile)
         \ . " | grep -m1 'Page:' | sed 's/Page://' | tr -d '\n'"
   let l:page = system(l:cmd)
   let g:latex#data[b:latex.id].cmds.view_mupdf_synctex = l:cmd
@@ -292,7 +292,7 @@ function! s:mupdf_start() "{{{1
   " Start MuPDF
   let exe = {}
   let exe.cmd  = 'mupdf ' .  g:latex_view_mupdf_options
-  let exe.cmd .= ' ' . shellescape(outfile)
+  let exe.cmd .= ' ' . latex#util#fnameescape(outfile)
   call latex#util#execute(exe)
   let g:latex#data[b:latex.id].cmds.view = exe.cmd
 


### PR DESCRIPTION
This fix is expected to resolve Issue #105 in which `latex#latexmk#compile()` gives a success message but actually does nothing on Windows with `shellslash` set. The cause of the problem is that `shellescape()` on Windows returns a string enclosed by single quotes with `shellslash`, while Windows `cmd` recognizes only double quotes.

The fix should be in effect for `vim-latex` on Windows only, except a small typo fix as a bonus. :)

Tested on Windows 7 SP1 64-bit, VIM 7.4.589 64-bit w/ and w/o `shellslash`.