### PR TITLE
Return an empty string in callback function

### DIFF
--- a/autoload/latex/latexmk.vim
+++ b/autoload/latex/latexmk.vim
@@ -91,6 +91,8 @@ function! latex#latexmk#callback(status) " {{{1
   if has_key(g:latex#data[b:latex.id].viewer, 'latexmk_callback')
     call g:latex#data[b:latex.id].viewer.latexmk_callback()
   endif
+
+  return ""
 endfunction
 
 " }}}1


### PR DESCRIPTION
On Windows, when executing the command `gvim --servername servername --remote-expr "latex#latexmk#callback(1)"` in a terminal, gvim opens the following window:

![callback-window](https://cloud.githubusercontent.com/assets/10026824/6443849/2daceabc-c0fa-11e4-9ed6-afc5b232e969.jpg)

By returning an empty string in `latex#latexmk#callback` function, this window disappears.

